### PR TITLE
Pin Golang to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang AS build-go
+FROM golang:1.22 AS build-go
 WORKDIR /build
 
 FROM gcc AS build-c
@@ -11,7 +11,7 @@ RUN wget https://github.com/tickstep/aliyunpan/archive/refs/tags/v${ALIYUNPAN_VE
     go build -o /aliyunpan
 
 FROM build-go AS baidupcs-build
-ENV BAIDUPCS_VERSION 3.9.4
+ENV BAIDUPCS_VERSION 3.9.5
 RUN wget https://github.com/qjfoidnh/BaiduPCS-Go/archive/refs/tags/v${BAIDUPCS_VERSION}.tar.gz -O baidupcs.tar.gz && \
     tar -xzf baidupcs.tar.gz --strip 1 && \
     go build -o /baidupcs


### PR DESCRIPTION
baidupcs fails to build under golang 1.23
https://github.com/qjfoidnh/BaiduPCS-Go/issues/336